### PR TITLE
FIX: 액션에서 타임존 설정 sudo 권한으로 실행

### DIFF
--- a/.github/workflows/TEST_REPORT.yml
+++ b/.github/workflows/TEST_REPORT.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Runner 타임존 설정
         run: |
-          timedatectl set-timezone 'Asia/Seoul'
+          sudo timedatectl set-timezone 'Asia/Seoul'
 
       - name: 패키지 설치
         working-directory: ./client


### PR DESCRIPTION
## 개요
FIX: 액션에서 타임존 설정 sudo 권한으로 실행

## 세부 내용
- 변경 전
  - 타임존 설정 시 권한 에러 발생
- 변경 후
  - sudo 권한 추가

## 공유

## relevant issue number
- #89 