### PR TITLE
FEAT: Todolist CRUD 및 타입 인터페이스 리팩터링

### DIFF
--- a/client/src/core/todo/test/generator.ts
+++ b/client/src/core/todo/test/generator.ts
@@ -1,4 +1,4 @@
-import { Todo } from '../todoList';
+import { Todo, PlainTodo } from '../todoList';
 
 const testToday = new Date();
 const DAY = 24 * 60 * 60 * 1000;
@@ -7,16 +7,16 @@ const WEEK = 7 * DAY;
 interface TestData {
   today: Date;
   tag: string;
-  data: Todo[];
+  data: PlainTodo[];
 }
 interface StrictCompareTestData {
   today: Date;
   tag: string;
-  problem: Todo[];
-  answer: Todo[];
+  problem: PlainTodo[];
+  answer: PlainTodo[];
 }
 
-const generateTodoForSortTest = (): Todo =>
+const generateTodoForSortTest = (): PlainTodo =>
   new Todo({
     owner: 'default owner',
     title: 'default title',
@@ -24,9 +24,10 @@ const generateTodoForSortTest = (): Todo =>
     until: new Date(testToday.getTime() + Math.floor(Math.random() * WEEK)),
     from: new Date(1994, 10, 5),
     state: 'READY',
-  });
+  }).toPlain();
 
-const generateTodoListForSortTest = (length: number): Todo[] => Array.from({ length }, () => generateTodoForSortTest());
+const generateTodoListForSortTest = (length: number): PlainTodo[] =>
+  Array.from({ length }, () => generateTodoForSortTest());
 
 // update
 const START = new Date('2022-8-31');
@@ -41,7 +42,7 @@ const getRandomState = (): 'READY' | 'DONE' | 'WAIT' =>
   // eslint-disable-next-line no-nested-ternary
   Math.random() < 0.5 ? 'DONE' : Math.random() < 0.5 ? 'READY' : 'WAIT';
 
-const generateRandomTodo = (id: string | undefined): Todo => {
+const generateRandomTodo = (id: string | undefined): PlainTodo => {
   const from = getRandomDate(START, END);
   const until = getDistantDate(from);
   return new Todo({
@@ -52,7 +53,7 @@ const generateRandomTodo = (id: string | undefined): Todo => {
     from,
     until,
     state: getRandomState(),
-  });
+  }).toPlain();
 };
 
 const getRandomIndex = (length: number, index: number, numNext: number): number =>
@@ -62,7 +63,7 @@ const getTodoIdFromNextElement = (
   length: number,
   index: number,
   numNext: number,
-  arr: Todo[],
+  arr: PlainTodo[],
 ): { idx: number[]; next: string[] } => {
   if (index + numNext >= length) return { next: [], idx: [] };
 
@@ -86,8 +87,8 @@ const generateRandomNumber = (p: number, max: number): number => {
   return num;
 };
 
-const generateTodoListForUpdateTest = (length: number): Todo[] => {
-  const todos: Todo[] = Array.from({ length }, (el, i) => generateRandomTodo(i.toString()));
+const generateTodoListForUpdateTest = (length: number): PlainTodo[] => {
+  const todos: PlainTodo[] = Array.from({ length }, (el, i) => generateRandomTodo(i.toString()));
   todos.forEach((el, i) => {
     const { idx, next } = getTodoIdFromNextElement(
       length,
@@ -104,28 +105,28 @@ const generateTodoListForUpdateTest = (length: number): Todo[] => {
   return todos;
 };
 
-const generateSortTestProblem = (answer: Todo[]): Todo[] => {
-  const problem = JSON.parse(JSON.stringify(answer)).map((el: any) => new Todo(el));
+const generateSortTestProblem = (answer: PlainTodo[]): PlainTodo[] => {
+  const problem = JSON.parse(JSON.stringify(answer)).map((el: any) => new Todo(el).toPlain());
   problem.sort(() => Math.random() - 0.5);
   return problem;
 };
 
-const changeTodoStateRandomly = (todo: Todo, p: number): Todo => {
+const changeTodoStateRandomly = (todo: PlainTodo, p: number): PlainTodo => {
   if (todo.state === 'DONE' || Math.random() < p) return todo;
-  if (todo.state === 'READY') return new Todo({ ...todo, state: 'WAIT' });
-  return new Todo({ ...todo, state: 'READY' });
+  if (todo.state === 'READY') return new Todo({ ...todo, state: 'WAIT' }).toPlain();
+  return new Todo({ ...todo, state: 'READY' }).toPlain();
 };
 
-const generateUpdateTestProblem = (answer: Todo[]): Todo[] => {
+const generateUpdateTestProblem = (answer: PlainTodo[]): PlainTodo[] => {
   const problem = JSON.parse(JSON.stringify(answer))
-    .map((el: any) => new Todo(el))
-    .map((el: Todo) => changeTodoStateRandomly(el, 0.8));
+    .map((el: any) => new Todo(el).toPlain())
+    .map((el: PlainTodo) => changeTodoStateRandomly(el, 0.8));
   return problem;
 };
 
 const generateTestCases = (
   answerObject: TestData,
-  generator: (answer: Todo[]) => Todo[],
+  generator: (answer: PlainTodo[]) => PlainTodo[],
   num: number,
 ): StrictCompareTestData[] =>
   new Array(num).fill(0).map((el, i) => ({
@@ -137,7 +138,7 @@ const generateTestCases = (
 
 const generateTestSet = (
   data: TestData[],
-  generator: (answer: Todo[]) => Todo[],
+  generator: (answer: PlainTodo[]) => PlainTodo[],
   multiplier: number,
 ): StrictCompareTestData[] => data.flatMap((el) => generateTestCases(el, generator, multiplier));
 

--- a/client/src/core/todo/test/sort.test.ts
+++ b/client/src/core/todo/test/sort.test.ts
@@ -1,19 +1,19 @@
-import { Todo, TodoList } from '../todoList';
-import { validateImminenceSort, validateImportanceSort, validateDeadlineSort } from './validator';
+import { Todo, TodoList, PlainTodo } from '../todoList';
+import { toComparableTodo, validateImminenceSort, validateImportanceSort, validateDeadlineSort } from './validator';
 import { testToday, generateTodoListForSortTest, generateSortTestSet } from './generator';
 import * as sortRawTestCase from './sort.data.json';
 
 const sortTestCase = sortRawTestCase.map((el) => ({
   tag: el.tag,
   today: new Date(el.today),
-  data: el.data.map(
-    (todo) => new Todo({ ...todo, owner: 'default owner', state: 'READY', importance: todo.importance as number }),
+  data: el.data.map((todo) =>
+    new Todo({ ...todo, owner: 'default owner', state: 'READY', importance: todo.importance as number }).toPlain(),
   ),
 }));
 
-const sort = (todoList: Todo[], today: Date): Todo[] => {
+const sort = async (todoList: PlainTodo[], today: Date): Promise<PlainTodo[]> => {
   const newTodoList = new TodoList(todoList);
-  return newTodoList.getSortedRTL(today);
+  return await newTodoList.getSortedRTL(today);
 };
 
 const testCases = new Array(10).fill(0).map((el, i) => ({
@@ -24,14 +24,17 @@ const testCases = new Array(10).fill(0).map((el, i) => ({
 
 describe('기본 정렬 테스트', () => {
   describe.each(testCases)('$tag', ({ data, today }) => {
-    it('다른 조건이 모두 동일하다면, Imminent Todo가 Active된다.', () => {
-      expect(validateImminenceSort(sort(data, today), today)).toBe(true);
+    it('다른 조건이 모두 동일하다면, Imminent Todo가 Active된다.', async () => {
+      const todoList = await sort(data, today);
+      expect(validateImminenceSort(todoList, today)).toBe(true);
     });
-    it('Imminence 정렬이 Importance 정렬보다 우선한다.', () => {
-      expect(validateImportanceSort(sort(data, today), today)).toBe(true);
+    it('Imminence 정렬이 Importance 정렬보다 우선한다.', async () => {
+      const todoList = await sort(data, today);
+      expect(validateImportanceSort(todoList, today)).toBe(true);
     });
-    it('Imminence 정렬이 Importance 정렬보다 우선하며, Importance 정렬이 EDF 정렬보다 우선한다.', () => {
-      expect(validateDeadlineSort(sort(data, today), today)).toBe(true);
+    it('Imminence 정렬이 Importance 정렬보다 우선하며, Importance 정렬이 EDF 정렬보다 우선한다.', async () => {
+      const todoList = await sort(data, today);
+      expect(validateDeadlineSort(todoList, today)).toBe(true);
     });
   });
 });
@@ -41,10 +44,10 @@ const macroUnitTestCases = generateSortTestSet(sortTestCase, 5);
 
 describe('정렬 대단위 테스트', () => {
   describe.each(macroUnitTestCases)('$tag', ({ problem, today, answer }) => {
-    it('Ready Todo List의 기본적인 정렬을 할 수 있다.', () => {
-      expect(sort(problem, today).map((el) => el.toComparableTodo())).toEqual(
-        answer.map((el) => el.toComparableTodo()),
-      );
+    it('Ready Todo List의 기본적인 정렬을 할 수 있다.', async () => {
+      const todoList = await sort(problem, today);
+
+      expect(todoList.map((el) => toComparableTodo(el))).toEqual(answer.map((el) => toComparableTodo(el)));
     });
   });
 });

--- a/client/src/core/todo/test/update.test.ts
+++ b/client/src/core/todo/test/update.test.ts
@@ -1,16 +1,17 @@
-import { Todo } from '../todoList';
-import { validateRTL, validateWTL } from './validator';
+import { PlainTodo, Todo, TodoList } from '../todoList';
+import { toComparableTodo, validateRTL, validateWTL } from './validator';
 import { testToday, generateTodoListForUpdateTest, generateUpdateTestSet } from './generator';
 import * as updateRawTestCase from './update.data.json';
 
 const updateTestCase = updateRawTestCase.map((el) => ({
   tag: el.tag,
   today: new Date(el.today),
-  data: el.data.map((todo) => new Todo({ ...todo, state: todo.state as 'DONE' | 'READY' | 'WAIT' })),
+  data: el.data.map((todo) => new Todo({ ...todo, state: todo.state as 'DONE' | 'READY' | 'WAIT' }).toPlain()),
 }));
 
-const update = (todoList: Todo[], today: Date): Todo[] => {
-  return [...todoList];
+const update = async (todoList: PlainTodo[], today: Date): Promise<PlainTodo[]> => {
+  const newTodoList = await new TodoList(todoList).updateAll(today);
+  return newTodoList.getTL();
 };
 
 const testCases = new Array(10).fill(0).map((el, i) => ({
@@ -21,11 +22,13 @@ const testCases = new Array(10).fill(0).map((el, i) => ({
 
 describe('업데이트 테스트', () => {
   describe.each(testCases)('$tag', ({ data, today }) => {
-    it('RTL 조건 확인', () => {
-      expect(validateRTL(update(data, today), today)).toBe(true);
+    it('RTL 조건 확인', async () => {
+      const todoList = await update(data, today);
+      expect(validateRTL(todoList, today)).toBe(true);
     });
-    it('WTL 조건 확인', () => {
-      expect(validateWTL(update(data, today), today)).toBe(true);
+    it('WTL 조건 확인', async () => {
+      const todoList = await update(data, today);
+      expect(validateWTL(todoList, today)).toBe(true);
     });
   });
 });
@@ -34,10 +37,9 @@ const macroUnitTestCases = generateUpdateTestSet(updateTestCase, 5);
 
 describe('업데이트 대단위 테스트', () => {
   describe.each(macroUnitTestCases)('$tag', ({ problem, today, answer }) => {
-    it('Todo List의 선후관계 및 날짜 비교를 통해 Todo들의 상태를 업데이트 할 수 있다.', () => {
-      expect(update(problem, today).map((el) => el.toComparableTodo())).toEqual(
-        answer.map((el: any) => el.toComparableTodo()),
-      );
+    it('Todo List의 선후관계 및 날짜 비교를 통해 Todo들의 상태를 업데이트 할 수 있다.', async () => {
+      const todoList = await update(problem, today);
+      expect(todoList.map((el) => toComparableTodo(el))).toEqual(answer.map((el: any) => toComparableTodo(el)));
     });
   });
 });

--- a/client/src/core/todo/test/validator.test.ts
+++ b/client/src/core/todo/test/validator.test.ts
@@ -13,14 +13,14 @@ import {
 const sortTestCase = sortRawTestCase.map((el) => ({
   tag: el.tag,
   today: new Date(el.today),
-  data: el.data.map(
-    (todo) => new Todo({ ...todo, owner: 'default owner', state: 'READY', importance: todo.importance as number }),
+  data: el.data.map((todo) =>
+    new Todo({ ...todo, owner: 'default owner', state: 'READY', importance: todo.importance as number }).toPlain(),
   ),
 }));
 const updateTestCase = updateRawTestCase.map((el) => ({
   tag: el.tag,
   today: new Date(el.today),
-  data: el.data.map((todo) => new Todo({ ...todo, state: todo.state as 'DONE' | 'READY' | 'WAIT' })),
+  data: el.data.map((todo) => new Todo({ ...todo, state: todo.state as 'DONE' | 'READY' | 'WAIT' }).toPlain()),
 }));
 
 describe('검증 알고리즘 테스트', () => {

--- a/client/src/core/todo/test/validator.ts
+++ b/client/src/core/todo/test/validator.ts
@@ -1,9 +1,18 @@
-import { Todo } from '../todoList';
+import { PlainTodo } from '../todoList';
 
 const onlyDate = (date: Date): Date => new Date(date.getFullYear(), date.getMonth(), date.getDate());
 const isEqualDate = (d1: Date, d2: Date): boolean => onlyDate(d1).getTime() === onlyDate(d2).getTime();
 
-const validateImminenceSort = (todoList: Todo[], testToday: Date): boolean => {
+const toComparableTodo = (todo: PlainTodo): any => {
+  return {
+    ...todo,
+    until: todo.until.getTime(),
+    from: todo.from.getTime(),
+    lastPostponed: todo.lastPostponed.getTime(),
+  };
+};
+
+const validateImminenceSort = (todoList: PlainTodo[], testToday: Date): boolean => {
   return todoList
     .map((el, i) => ({ index: i, todo: el }))
     .filter((el) => isEqualDate(testToday, el.todo.until))
@@ -12,56 +21,52 @@ const validateImminenceSort = (todoList: Todo[], testToday: Date): boolean => {
     }, true);
 };
 
-const validateImportance = (todoList: Todo[]): boolean =>
-  todoList.reduce((acc, el, i, arr) => acc && (i === 0 || el.importance <= arr[i - 1].importance), true);
+const validateImportance = (todoList: PlainTodo[]): boolean =>
+  todoList.every((el, i, arr) => i === 0 || el.importance <= arr[i - 1].importance);
 
-const validateImportanceSort = (todoList: Todo[], testToday: Date): boolean => {
+const validateImportanceSort = (todoList: PlainTodo[], testToday: Date): boolean => {
   if (!validateImminenceSort(todoList, testToday)) return false;
   const divider = todoList.filter((el) => isEqualDate(testToday, el.until)).length;
   return validateImportance(todoList.slice(0, divider)) && validateImportance(todoList.slice(divider));
 };
 
-const equalForImportanceSort = (todo1: Todo, todo2: Todo): boolean => {
+const equalForImportanceSort = (todo1: PlainTodo, todo2: PlainTodo): boolean => {
   return todo1.importance === todo2.importance;
 };
 
-const validateDeadlineSort = (todoList: Todo[], testToday: Date): boolean => {
+const validateDeadlineSort = (todoList: PlainTodo[], testToday: Date): boolean => {
   if (!validateImportanceSort(todoList, testToday)) return false;
-  todoList.reduce(
-    (acc, el, i, arr) => i === 0 || (acc && (!equalForImportanceSort(el, arr[i - 1]) || el.until >= arr[i - 1].until)),
-    true,
-  );
-  return true;
+  return todoList.every((el, i, arr) => {
+    return i === 0 || !equalForImportanceSort(el, arr[i - 1]) || el.until >= arr[i - 1].until;
+  });
 };
 
-const equalForDeadlineSort = (todo1: Todo, todo2: Todo): boolean => {
+const equalForDeadlineSort = (todo1: PlainTodo, todo2: PlainTodo): boolean => {
   return todo1.importance === todo2.importance && todo1.until.getTime() === todo2.until.getTime();
 };
 
-const validateLastPostponedSort = (todoList: Todo[], testToday: Date): boolean => {
+const validateLastPostponedSort = (todoList: PlainTodo[], testToday: Date): boolean => {
   if (!validateDeadlineSort(todoList, testToday)) return false;
-  todoList.reduce(
-    (acc, el, i, arr) =>
-      i === 0 || (acc && (!equalForDeadlineSort(el, arr[i - 1]) || el.lastPostponed >= arr[i - 1].lastPostponed)),
-    true,
-  );
-  return true;
+  return todoList.every((el, i, arr) => {
+    return i === 0 || !equalForDeadlineSort(el, arr[i - 1]) || el.lastPostponed >= arr[i - 1].lastPostponed;
+  });
 };
 
 const isFromBeforeToday = (testToday: Date, from: Date): boolean => from.getTime() <= testToday.getTime();
-const isAllPrevDone = (todo: Todo, todoList: Todo[]): boolean =>
-  todo.prev.reduce((acc, id) => acc && todoList.find((el) => el.id === id)?.state === 'DONE', true);
+const isAllPrevDone = (todo: PlainTodo, todoList: PlainTodo[]): boolean =>
+  todo.prev.every((id) => todoList.find((el) => el.id === id)?.state === 'DONE');
 
-const validateRTL = (todoList: Todo[], testToday: Date): boolean =>
+const validateRTL = (todoList: PlainTodo[], testToday: Date): boolean =>
   todoList
     .filter((el) => el.state === 'READY')
-    .reduce((acc, el) => acc && isFromBeforeToday(testToday, el.from) && isAllPrevDone(el, todoList), true);
+    .every((el) => isFromBeforeToday(testToday, el.from) && isAllPrevDone(el, todoList));
 
-const validateWTL = (todoList: Todo[], testToday: Date): boolean =>
+const validateWTL = (todoList: PlainTodo[], testToday: Date): boolean =>
   todoList
     .filter((el) => el.state === 'WAIT')
-    .reduce((acc, el) => acc && (!isFromBeforeToday(testToday, el.from) || !isAllPrevDone(el, todoList)), true);
+    .every((el) => !isFromBeforeToday(testToday, el.from) || !isAllPrevDone(el, todoList));
 export {
+  toComparableTodo,
   validateImminenceSort,
   validateImportanceSort,
   validateDeadlineSort,

--- a/client/src/core/todo/todoList.ts
+++ b/client/src/core/todo/todoList.ts
@@ -239,7 +239,21 @@ export class TodoList {
   }
 
   getSummary(): any {
-    return '';
+    return {
+      numberOfImminenceTodos: this.todoList
+        .filter((el) => el.state === 'READY')
+        .filter((el) => isEqualDate(el.until, new Date())).length,
+      numberOfDistantTodos: this.todoList
+        .filter((el) => el.state === 'READY')
+        .filter((el) => !isEqualDate(el.until, new Date())).length,
+      numberOfReadyStateTodos: this.todoList.filter((el) => el.state === 'READY').length,
+      numberOfWaitStateTodos: this.todoList.filter((el) => el.state === 'WAIT').length,
+      numberOfTotalTodos: this.todoList.length,
+      numberOfRemainingTodos: -1,
+      numberOfPostpones: -1,
+      TotalElapsedTime: -1,
+      numberOfTodayDoneTodos: -1,
+    };
   }
 
   private checkPrev(todo: Todo): boolean {

--- a/client/src/core/todo/todoList.ts
+++ b/client/src/core/todo/todoList.ts
@@ -301,6 +301,15 @@ export class TodoList {
   }
 
   async remove(id: string): Promise<TodoList> {
+    const newTodo = this.todoList.find((el) => el.id === id);
+    if (newTodo === undefined) throw new Error('ERROR: 지우려는 ID의 Todo가 존재하지 않습니다.');
+
+    this.getPrev(newTodo).forEach((el) => el.removeNext(newTodo.id));
+
+    this.getNext(newTodo).forEach((el) => el.removePrev(newTodo.id));
+
+    this.getNext(newTodo).forEach((el) => this.updateTodoState(el));
+
     return new TodoList(this.todoList.filter((el) => el.id !== id).map((el) => el.toPlain()));
   }
 

--- a/client/src/core/todo/todoList.ts
+++ b/client/src/core/todo/todoList.ts
@@ -295,8 +295,24 @@ export class TodoList {
   }
 
   async edit(id: string, todo: InputTodo): Promise<TodoList> {
-    const newTodoList = this.todoList.filter((el) => el.id !== id);
-    newTodoList.push(new Todo({ ...todo, id }));
+    const oldTodo = this.todoList.find((el) => el.id === id);
+    if (oldTodo === undefined) throw new Error('ERROR: 수정하려는 ID의 Todo가 존재하지 않습니다.');
+    const newTodo = new Todo(todo);
+
+    this.getPrev(oldTodo).forEach((el) => el.removeNext(oldTodo.id));
+    this.getPrev(newTodo).forEach((el) => el.addNext(newTodo.id));
+
+    this.updateTodoState(newTodo);
+
+    this.getNext(oldTodo).forEach((el) => el.removePrev(oldTodo.id));
+    this.getNext(newTodo).forEach((el) => el.addPrev(newTodo.id));
+
+    this.getNext(oldTodo).forEach((el) => this.updateTodoState(el));
+    this.getNext(newTodo).forEach((el) => this.updateTodoState(el));
+
+    const newTodoList = this.todoList.filter((el) => el !== oldTodo);
+    newTodoList.push(newTodo);
+
     return new TodoList(newTodoList.map((el) => el.toPlain()));
   }
 

--- a/client/src/core/todo/todoList.ts
+++ b/client/src/core/todo/todoList.ts
@@ -157,6 +157,26 @@ export class Todo implements InputTodo {
       lastPostponed: this.lastPostponed.getTime(),
     };
   }
+
+  addPrev(id: string): Todo {
+    return this;
+  }
+
+  addNext(id: string): Todo {
+    return this;
+  }
+
+  removePrev(id: string): Todo {
+    return this;
+  }
+
+  removeNext(id: string): Todo {
+    return this;
+  }
+
+  updateState(): Todo {
+    return this;
+  }
 }
 export class TodoList {
   private readonly todoList: Todo[];
@@ -227,7 +247,17 @@ export class TodoList {
   }
 
   async add(todo: InputTodo): Promise<TodoList> {
+    // push new Todo
     this.todoList.push(new Todo(todo));
+
+    // add mySelf as next to my prev Todo
+
+    // update mySelf
+
+    // add mySelf as prev to my next Todo
+
+    // update next Todo
+
     return new TodoList(this.todoList);
   }
 

--- a/client/src/core/todo/todoList.ts
+++ b/client/src/core/todo/todoList.ts
@@ -226,19 +226,9 @@ export class TodoList {
   }
 
   async setDone(): Promise<TodoList> {
-    // this.getActiveTodoAsInstance()
-    //   .setDone()
-    //   .next.forEach((nid) => {
-    //     const nextTodo = this.todoList.find((el) => el.id === nid);
-    //     if (nextTodo === undefined) return;
-    //     if (
-    //       nextTodo.prev.every((pid) => this.todoList.find((el) => el.id === pid)?.state === 'DONE') &&
-    //       nextTodo.isFromBeforeToday()
-    //     ) {
-    //       return nextTodo.setReady();
-    //     }
-    //     return nextTodo.setWait();
-    //   });
+    const activeTodo = this.getActiveTodoAsInstance();
+    activeTodo.setDone();
+    this.getNext(activeTodo).forEach((el) => this.updateTodoState(el));
 
     return new TodoList(this.todoList.map((el) => el.toPlain()));
   }

--- a/client/src/core/todo/todoList.ts
+++ b/client/src/core/todo/todoList.ts
@@ -32,20 +32,26 @@ const compareFunctions = {
   },
 };
 
-export interface InputTodo {
+export interface PlainTodo {
   id: string; // UUIDv4, 할일의 고유 id
   title: string; // VARCHAR(255), 할일의 이름
   content: string; // TEXT, 할일의 상세 내용
   owner: string; // UUIDv4, 할일 소유자의 id
   importance: number; // INT or ENUM, 할일의 우선순위 레벨
-  until: Date | string; // DATE, 할일의 마감기한
-  from: Date | string; // DATE, 할일의 시작기한
+  until: Date; // DATE, 할일의 마감기한
+  from: Date; // DATE, 할일의 시작기한
   prev: string[]; // or string[], 이전에 반드시 완료되어야 하는 할일 id 배열
   next: string[]; // or string[], 본 할일 이후에 실행되어야 하는 할일 id 배열
   elapsedTime: number;
-  lastPostponed: Date | string;
+  lastPostponed: Date;
   state: 'READY' | 'DONE' | 'WAIT';
 }
+
+export type InputTodo = Partial<Omit<PlainTodo, 'until' | 'from' | 'lastPostponed'>> & {
+  until?: Date | string;
+  from?: Date | string;
+  lastPostponed?: Date | string;
+};
 
 export class Todo {
   id: string;

--- a/client/src/core/todo/todoList.ts
+++ b/client/src/core/todo/todoList.ts
@@ -252,17 +252,44 @@ export class TodoList {
     return '';
   }
 
+  private checkPrev(todo: Todo): boolean {
+    return [...todo.prev].every((prevId) => this.todoList.find((el) => el.id === prevId)?.state === 'DONE');
+  }
+
+  private checkFrom(todo: Todo): boolean {
+    return todo.from < new Date();
+  }
+
+  private updateTodoState(todo: Todo): Todo {
+    if (this.checkFrom(todo) && this.checkPrev(todo)) todo.state = 'READY';
+    else todo.state = 'WAIT';
+    return todo;
+  }
+
+  private getPrev(todo: Todo): Todo[] {
+    return [...todo.prev]
+      .map((prevId) => this.todoList.find((el) => el.id === prevId))
+      .filter((el) => el !== undefined) as Todo[];
+  }
+
+  private getNext(todo: Todo): Todo[] {
+    return [...todo.next]
+      .map((nextId) => this.todoList.find((el) => el.id === nextId))
+      .filter((el) => el !== undefined) as Todo[];
+  }
+
   async add(todo: InputTodo): Promise<TodoList> {
-    // push new Todo
-    this.todoList.push(new Todo(todo));
+    const newTodo = new Todo(todo);
 
-    // add mySelf as next to my prev Todo
+    this.getPrev(newTodo).forEach((el) => el.addNext(newTodo.id));
 
-    // update mySelf
+    this.updateTodoState(newTodo);
 
-    // add mySelf as prev to my next Todo
+    this.getNext(newTodo).forEach((el) => el.addPrev(newTodo.id));
 
-    // update next Todo
+    this.getNext(newTodo).forEach((el) => this.updateTodoState(el));
+
+    this.todoList.push(newTodo);
 
     return new TodoList(this.todoList.map((el) => el.toPlain()));
   }


### PR DESCRIPTION
## 개요
- Todolist CRUD에서 prev, next Todo들의 상태 업데이트 코드를 추가 및 리팩터링했습니다.
- 목적에 따라서 Todo의 인터페이스를 세분화했습니다.
- 테스트 코드를 리팩터링했습니다.

## 세부 내용
- CRUD 코드 리팩터링
  - prev, next Todo들을 get하는 부분을 리팩터링했습니다.
  - Todo상태를 업데이트하는 부분을 리팩터링했습니다.
  - 에러를 던집니다.
- Todo의 인터페이스를 세분화
  - Todo 
    - Todo를 담는 클래스 
  - PlainTodo 
    - TodoList와 Todo에서 순수성 유지와 메서드 접근 제한을 위해 Todo 대신 반환하는 Plain 객체
    - Date 관련한 필드를 Date 타입으로 가집니다. 
  - InputTodo
    - TodoList와 Todo에서 필요한 필드 값이 결여된 Plain 객체를 입력 받기 위한 인터페이스
 - 테스트 코드를 리팩터링했습니다.
   - 비동기로 동작하는 TodoList 메서드들을 테스트하기 위해 동기적으로 작동하는 테스트 코드를 비동기적으로 작동하도록 수정했습니다. 
## 공유
- 고민과 질문
## relevant issue number
- #57
- #59
- #82
- #100
