### PR TITLE
FIX: id로 Todo 가져오기 메서드 구현

### DIFF
--- a/client/src/core/todo/todoList.ts
+++ b/client/src/core/todo/todoList.ts
@@ -355,4 +355,8 @@ export class TodoList {
     this.todoList.filter((el) => el.state === type).sort(generateCompare(compareArr));
     return new TodoList(this.todoList.map((el) => el.toPlain()));
   }
+
+  async getTodoById(id: string): Promise<PlainTodo | undefined> {
+    return this.todoList.find((el) => el.id === id)?.toPlain();
+  }
 }


### PR DESCRIPTION
<!-- 제목형식 FEAT: 내용 -->
## 개요
- id로 Todo 가져오는 메서드를 구현했습니다. 
## 세부 내용
- `getTodoById(id:string) : Promise<PlainTodo | undefined>`
## 공유
- https://github.com/boostcampwm-2022/web20-OAO/wiki/TodoList-API

## relevant issue number
- #125
