### PR TITLE
FIX: getSortedList 메서드 PlainTodo를 리턴하도록 수정

### DIFF
--- a/client/src/core/todo/todoList.ts
+++ b/client/src/core/todo/todoList.ts
@@ -341,7 +341,7 @@ export class TodoList {
     return new TodoList(this.todoList.filter((el) => el.id !== id).map((el) => el.toPlain()));
   }
 
-  async getSortedList(type: 'READY' | 'WAIT' | 'DONE', compareArr: string[]): Promise<TodoList> {
+  async getSortedList(type: 'READY' | 'WAIT' | 'DONE', compareArr: string[]): Promise<PlainTodo[]> {
     const generateCompare = (compareArr: string[]) => {
       return (a: Todo, b: Todo): number => {
         let result = 0;
@@ -352,8 +352,8 @@ export class TodoList {
         return result;
       };
     };
-    this.todoList.filter((el) => el.state === type).sort(generateCompare(compareArr));
-    return new TodoList(this.todoList.map((el) => el.toPlain()));
+    const newTodoList = this.todoList.filter((el) => el.state === type).sort(generateCompare(compareArr));
+    return newTodoList.map((el) => el.toPlain());
   }
 
   async getTodoById(id: string): Promise<PlainTodo | undefined> {


### PR DESCRIPTION
<!-- 제목형식 FEAT: 내용 -->
## 개요
- getSortedList 메서드가 정렬된 Todo들의 PlainTodo 배열을 반환하도록 수정함.

## 공유
- https://github.com/boostcampwm-2022/web20-OAO/wiki/TodoList-API
## relevant issue number
- #127 
