### PR TITLE
FIX: oldTodo의 next Todo들이 다시 oldTodo에만 접근할 수 있는 문제 해결

### DIFF
--- a/client/src/core/todo/todoList.ts
+++ b/client/src/core/todo/todoList.ts
@@ -191,6 +191,7 @@ export class TodoList {
     this.getNext(oldTodo).forEach((el) => el.removePrev(oldTodo.id));
     this.getNext(newTodo).forEach((el) => el.addPrev(newTodo.id));
     this.getNext(oldTodo).forEach((el) => this.updateTodoState(el));
+    oldTodo.state = newTodo.state;
     this.getNext(newTodo).forEach((el) => this.updateTodoState(el));
 
     const newTodoList = await this.db.editMany([...changedTodoSet].map((el) => ({ id: el.id, todo: el.toPlain() })));


### PR DESCRIPTION
## 개요
oldTodo의 next Todo들이 다시 oldTodo에만 접근할 수 있는 문제 해결 

## relevant issue number
- #137 
