### PR TITLE
FIX: remote server todos path proxy 설정

### DIFF
--- a/client/default.conf
+++ b/client/default.conf
@@ -1,7 +1,7 @@
 server {
     listen 3000;
+    root /dist;
     location / {
-        root /dist;
-        index index.html index.htm;
+        try_files $uri $uri/ $uri.html /index.html;
     }
 }


### PR DESCRIPTION
## 개요
client docker nginx에서 /todos 경로 접속시 404에러 수정
## 세부 내용
client docker default.conf에서 / 이외 경로 설정을 해주지 않았음.
/{path name}으로 접속시, {path name}.html을 찾고, 없다면 index.html를 해당 경로로 보여줌

## 공유

- 고민과 질문
  
- 해결 과정의 기록은 정리해서 위키에 수록 후 링크 달기
  
## 관련 이슈

- #156 