### PR TITLE
feat: CI/CD github action 수정 및 메인 nginx dockerfile 이미 있는 이미지로 대체

### DIFF
--- a/.github/workflows/CLIENT_BUILD.yml
+++ b/.github/workflows/CLIENT_BUILD.yml
@@ -54,16 +54,6 @@ jobs:
           tags: ghcr.io/kumsil1006/oao-client:${{ steps.tag_version.outputs.previous_tag }},ghcr.io/kumsil1006/oao-client:latest
           context: ./client
 
-      - name: Docker Compose 파일 운영 서버로 복사
-        uses: appleboy/scp-action@master
-        with:
-          host: ${{ secrets.RELEASE_HOST }}
-          username: ${{ secrets.RELEASE_USERNAME }}
-          password: ${{ secrets.RELEASE_PASSWORD }}
-          port: ${{ secrets.RELEASE_PORT }}
-          source: "docker-compose.yml"
-          target: "oao"
-
       - name: 운영 서버에서 Docker Compose 실행
         uses: appleboy/ssh-action@master
         with:
@@ -74,11 +64,10 @@ jobs:
           script: |
             echo ${{secrets.CONTAINER_REGISTRY_TOKEN}} | docker login ghcr.io -u kumsil1006 --password-stdin
             docker pull ghcr.io/kumsil1006/oao-client
-            docker pull ghcr.io/kumsil1006/oao-proxy
 
             cd oao
 
-            docker-compose up -d
+            docker compose -f docker-compose.product.yml up -d
             docker image prune
 
       - name: 실패시 슬랙 메시지 전송

--- a/.github/workflows/CLIENT_DEV_BUILD.yml
+++ b/.github/workflows/CLIENT_DEV_BUILD.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - main
-      
+
     paths:
       - "client/**"
 
@@ -69,7 +69,6 @@ jobs:
           script: |
             echo ${{secrets.CONTAINER_REGISTRY_TOKEN}} | docker login ghcr.io -u kumsil1006 --password-stdin
             docker pull ghcr.io/kumsil1006/oao-dev-client
-            docker pull ghcr.io/kumsil1006/oao-dev-proxy
 
             cd oao
 

--- a/.github/workflows/SERVER_BUILD.yml
+++ b/.github/workflows/SERVER_BUILD.yml
@@ -46,16 +46,6 @@ jobs:
           push: true
           tags: ghcr.io/kumsil1006/oao-server:${{ steps.tag_version.outputs.previous_tag }},ghcr.io/kumsil1006/oao-server:latest
 
-      - name: Docker Compose 파일 운영 서버로 복사
-        uses: appleboy/scp-action@master
-        with:
-          host: ${{ secrets.RELEASE_HOST }}
-          username: ${{ secrets.RELEASE_USERNAME }}
-          password: ${{ secrets.RELEASE_PASSWORD }}
-          port: ${{ secrets.RELEASE_PORT }}
-          source: "docker-compose.yml"
-          target: "oao"
-
       - name: 운영 서버에서 Docker Compose 실행
         uses: appleboy/ssh-action@master
         with:
@@ -66,11 +56,10 @@ jobs:
           script: |
             echo ${{secrets.CONTAINER_REGISTRY_TOKEN}} | docker login ghcr.io -u kumsil1006 --password-stdin
             docker pull ghcr.io/kumsil1006/oao-server
-            docker pull ghcr.io/kumsil1006/oao-proxy
 
             cd oao
 
-            docker-compose up -d
+            docker compose -f docker-compose.product.yml up -d
             docker image prune
 
       - name: 실패시 슬랙 메시지 전송

--- a/.github/workflows/SERVER_DEV_BUILD.yml
+++ b/.github/workflows/SERVER_DEV_BUILD.yml
@@ -60,7 +60,6 @@ jobs:
           script: |
             echo ${{secrets.CONTAINER_REGISTRY_TOKEN}} | docker login ghcr.io -u kumsil1006 --password-stdin
             docker pull ghcr.io/kumsil1006/oao-dev-server
-            docker pull ghcr.io/kumsil1006/oao-dev-proxy
 
             cd oao
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+#dockerfile
+docker-compose.product.yml
+default.product.conf
+
 # dependencies
 node_modules
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,12 @@
 version: "3.9"
 services:
   proxy:
-    image: "ghcr.io/kumsil1006/oao-dev-proxy:latest"
+    image: "nginx:latest"
     ports:
       - "80:80"
     restart: always
+    volumes:
+      - ./conf/default.conf:/etc/nginx/conf.d/default.conf
   frontend:
     image: "ghcr.io/kumsil1006/oao-dev-client:latest"
     restart: always

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,4 +1,0 @@
-FROM nginx
-COPY ./default.conf /etc/nginx/conf.d/default.conf
-
-RUN apt-get update && apt-get install vim -y


### PR DESCRIPTION
## 개요
<img width="942" alt="스크린샷 2022-12-09 오전 1 50 08" src="https://user-images.githubusercontent.com/97649363/206513545-30455d1e-d78f-4352-9a7d-f67e98fd753a.png">
- ssl 인증서 적용된 사진

CI/CD github action 수정 및 메인 nginx dockerfile 이미 있는 이미지로 대체

## 세부 내용
- docker compose시 nginx 이미지는 이미 있는 이미지를 가져와 사용하게 수정하였습니다
- github action에서 기존에는 release 서버에서도 github repo의 `docker-compose.yml`를 복사하여 사용하였는데 복사하지 않고 서버에 있는 파일을 이용하도록 수정하였습니다.  
  - release 서버에서 이용하는 `docker-compose.product.yml`와 nginx의 `default.conf`는 github에 올리지않습니다

## 공유

- 고민과 질문
  
- 해결 과정의 기록은 정리해서 위키에 수록 후 링크 달기
  
## 관련 이슈

- #201 
