### PR TITLE
FIX: todo간 순환참조 예외 처리

### DIFF
--- a/client/src/components/diagram/TodoVertexPopUp.tsx
+++ b/client/src/components/diagram/TodoVertexPopUp.tsx
@@ -24,7 +24,7 @@ const TodoVertexPopUp = ({ id, x, y }: { id: string; x: number; y: number }): Re
             })
             .then((newTodoList) => {
               setTodoList(newTodoList);
-              toast.success('Todo가 성공적으로 삭제되었습니다.');
+              toast.success('Todo 선후관계가 성공적으로 삭제되었습니다.');
             })
             .catch((err) => toast.error(err));
         }}

--- a/client/src/container/todos/TableModal.tsx
+++ b/client/src/container/todos/TableModal.tsx
@@ -147,17 +147,7 @@ const TableModal = (): ReactElement => {
           return (newData = { ...newData, [id]: new Date(value) });
         }
         if (dataset.label === 'prev' || dataset.label === 'next') {
-          if (dataset.id === editingTodoId)
-            throw new Error('수정하고 있는 할 일은 먼저 할 일과 나중에 할 일에 들어갈 수 없습니다');
           if (modalType === update) validateUuid(dataset.id);
-          const isprevIdCircularReference =
-            dataset.label === 'prev'
-              ? validateCircularReference(nextTodoIdList, dataset.id)
-              : validateCircularReference(prevTodoIdList, dataset.id);
-          if (isprevIdCircularReference)
-            throw new Error(
-              `먼저 할 일과 나중에 할 일에는 같은 할 일이 올 수 없습니다. 둘 중 하나에서 "${value}" 지워주세요`,
-            );
           return dataset.label === 'prev' ? prevTodoIdList.push(dataset.id) : nextTodoIdList.push(dataset.id);
         }
         newData = { ...newData, [id]: value };

--- a/client/src/core/todo/todoList.ts
+++ b/client/src/core/todo/todoList.ts
@@ -280,9 +280,11 @@ export class TodoList {
     const result = next
       .map((el) => ({ id: el, check: dfsForward(el) }))
       .concat(prev.map((el) => ({ id: el, check: dfsBackward(el) })));
-    const errorArr = result
-      .filter((el) => !el.check)
-      .map((el) => this.todoList.find((target) => target.id === el.id)?.title);
+    const errorArr = [
+      ...new Set(
+        result.filter((el) => !el.check).map((el) => this.todoList.find((target) => target.id === el.id)?.title),
+      ),
+    ];
     if (errorArr.length !== 0)
       throw new Error(`순환 참조를 유발하는 선후 관계가 있습니다. 원인: [${errorArr.join(', ')}]`);
     return errorArr.length === 0;


### PR DESCRIPTION
## 개요
todo간 순환참조 예외 처리

## 세부 내용
- todo간 순환참조 예외 처리
  - todo edit, add 시에 자동으로 체크 후 예외처리
- 기존에 Table Modal에서 별도로 이루어지던 예외처리 부분 삭제

## 공유
- 고민과 질문
  - 어떤 Todo가 문제인지 명확하게 알려주는 것이 좋은 방법일까?
  
## 관련 이슈
- #216 
