### PR TITLE
FIX: activeTodo에 마감일이 지나간 Todo가 나타나지 않는 문제 해결

### DIFF
--- a/client/src/core/todo/todoList.ts
+++ b/client/src/core/todo/todoList.ts
@@ -36,7 +36,7 @@ export class TodoList {
   }
 
   private getActiveTodoAsInstance(): Todo {
-    return this.todoList.filter((el) => el.state === 'READY').sort(Todo.compare())[0];
+    return this.todoList.filter((el) => el.state === 'READY').sort(defaultCompare)[0];
   }
 
   private getActiveTodoId(): string {


### PR DESCRIPTION
## 개요
- activeTodo에 마감일이 지나간 Todo가 나타나지 않는 문제 해결

## 세부 내용
- 초기 기획과 달리 imminence를 오늘인 할일 > 마감일이 남은 할일이 아니라, 마감일이 지난 할일 > 오늘인 할일 > 마감일이 남은 할일 순으로 정렬하도록 서비스 로직을 변경하여, 이에 따른 변경이 이루어짐.
- `getActiveTodo`가 일반화된 비교함수를 사용하지 않았던것이 주 원인으로, 다른 로직들은 비교함수 업데이트가 적용되었으나 `getActiveTodo`는 다른 함수를 사용하고 있어 적용되지 않았었음.

## 관련 이슈
- #240 
