### PR TITLE
FIX: 다이어그램 뷰의 위상정렬이 특정 상황에 제대로 이루어지 않는 버그

### DIFF
--- a/client/src/util/diagram.util.ts
+++ b/client/src/util/diagram.util.ts
@@ -1,5 +1,6 @@
 import { TodoList } from '@todo/todoList';
 import { Todo } from '@todo/todo';
+import { PlainTodo } from '@todo/todo.type';
 import Queue from '@util/queue';
 
 export interface DiagramTodo {
@@ -9,9 +10,10 @@ export interface DiagramTodo {
 }
 
 const topologySort = async (todoList: TodoList, showDone: boolean): Promise<Map<string, DiagramTodo>> => {
-  const filter = showDone ? () => true : (el: Todo) => el.state !== 'DONE';
+  const filter = showDone ? () => true : (el: Todo | PlainTodo) => el.state !== 'DONE';
   const sortedTodoList = await todoList.getSortedListWithFilter(filter, []);
   const cloneTodoList = new Map<string, Todo>(sortedTodoList.map((el) => [el.id, new Todo(el)]));
+  // Diagram에서 사용하지 않는 선후관계 의존성 제거
   cloneTodoList.forEach((el) => {
     el.prev.forEach((prevId) => {
       if (!cloneTodoList.has(prevId)) el.prev.delete(prevId);
@@ -20,9 +22,11 @@ const topologySort = async (todoList: TodoList, showDone: boolean): Promise<Map<
       if (!cloneTodoList.has(nextId)) el.next.delete(nextId);
     });
   });
+  // 결과값 템플릿 오브젝트 생성
   const resultTodoList = new Map<string, DiagramTodo>(
     sortedTodoList.map((el) => [el.id, { depth: NaN, todo: new Todo(el) }]),
   );
+  // 결과값들에서도 Diagram에서 사용하지 않는 선후관계 의존성 제거
   resultTodoList.forEach((el) => {
     el.todo.prev.forEach((prevId) => {
       if (!cloneTodoList.has(prevId)) el.todo.prev.delete(prevId);
@@ -35,23 +39,24 @@ const topologySort = async (todoList: TodoList, showDone: boolean): Promise<Map<
   const updateDepth = (id: string, depth: number): void => {
     const target = resultTodoList.get(id);
     if (target !== undefined) {
-      target.depth = depth;
+      resultTodoList.set(id, { ...target, depth });
     }
   };
 
   const checkPrev = (id: string): boolean => {
     const target = cloneTodoList.get(id);
     if (target == null) throw new Error('ERROR: 찾으려는 id의 Todo가 없습니다.');
-    return [...target.prev].every((prevId) => cloneTodoList.get(prevId)?.state === 'DONE');
+    return target.prev.size === 0;
   };
 
   const zeroDepthTodoList = sortedTodoList
-    .filter((el) => (showDone ? true : el.state !== 'DONE') && checkPrev(el.id))
+    .filter((el) => filter(el) && checkPrev(el.id))
     .map((el) => ({ depth: 0, id: el.id }));
 
   const forwardQueue = new Queue(zeroDepthTodoList);
   while (!forwardQueue.isEmpty()) {
     const target = forwardQueue.pop();
+    console.log(target);
     updateDepth(target.id, target.depth);
     const todo = cloneTodoList.get(target.id);
     if (todo === undefined) continue;
@@ -66,8 +71,10 @@ const topologySort = async (todoList: TodoList, showDone: boolean): Promise<Map<
   }
 
   const activeTodo = sortedTodoList.find((el) => el.state === 'READY')?.id;
-  const baseDepth = resultTodoList.get(activeTodo as string)?.depth;
-  resultTodoList.forEach((el) => ((el.depth as number) -= baseDepth as number));
+  if (activeTodo !== undefined) {
+    const baseDepth = resultTodoList.get(activeTodo)?.depth;
+    resultTodoList.forEach((el) => ((el.depth as number) -= baseDepth as number));
+  }
 
   return resultTodoList;
 };

--- a/client/src/util/diagram.util.ts
+++ b/client/src/util/diagram.util.ts
@@ -87,8 +87,8 @@ const calcOrder = (todoList: Map<string, DiagramTodo>): Map<string, DiagramTodo>
     if (i !== 0 && todo.depth === arr[i - 1][1].depth) j++;
     todo.order = i + j;
   });
-  const offset = todoListArr.find((el) => el[1].depth === 0)?.[1].order;
-  return new Map(todoListArr.map((el) => [el[0], { ...el[1], order: (el[1].order as number) - (offset as number) }]));
+  const offset = todoListArr.find((el) => el[1].todo.state === 'READY')?.[1].order ?? 0;
+  return new Map(todoListArr.map((el) => [el[0], { ...el[1], order: (el[1].order as number) - offset }]));
 };
 
 export const getDiagramData = async (todoList: TodoList, showDone: boolean): Promise<Map<string, DiagramTodo>> => {

--- a/client/src/util/diagram.util.ts
+++ b/client/src/util/diagram.util.ts
@@ -56,7 +56,6 @@ const topologySort = async (todoList: TodoList, showDone: boolean): Promise<Map<
   const forwardQueue = new Queue(zeroDepthTodoList);
   while (!forwardQueue.isEmpty()) {
     const target = forwardQueue.pop();
-    console.log(target);
     updateDepth(target.id, target.depth);
     const todo = cloneTodoList.get(target.id);
     if (todo === undefined) continue;

--- a/client/src/util/diagram.util.ts
+++ b/client/src/util/diagram.util.ts
@@ -69,11 +69,8 @@ const topologySort = async (todoList: TodoList, showDone: boolean): Promise<Map<
     });
   }
 
-  const activeTodo = sortedTodoList.find((el) => el.state === 'READY')?.id;
-  if (activeTodo !== undefined) {
-    const baseDepth = resultTodoList.get(activeTodo)?.depth;
-    resultTodoList.forEach((el) => ((el.depth as number) -= baseDepth as number));
-  }
+  const baseDepth = resultTodoList.get(sortedTodoList.find((el) => el.state === 'READY')?.id as string)?.depth ?? 0;
+  resultTodoList.forEach((el) => ((el.depth as number) -= baseDepth));
 
   return resultTodoList;
 };


### PR DESCRIPTION
## 개요
- 다이어그램 뷰의 위상정렬이 특정 상황에 제대로 이루어지 않는 버그

## 세부 내용
- **문제**
  - 위상정렬 결과값의 Depth와 Order 원점을 설정이 제대로 이루어지지 않아 버그가 발생함.
  - Depth의 경우 activeTodo를 기준으로 하나, activeTodo가 없는 경우에 대한 처리가 없었음.
  - Order의 경우 activeTodo를 기준으로 해야하나 0 Depth의 첫번째 요소를 기준으로 하고 있었음.
- **해결**
  - Depth 계산시에 activeTodo가 없으면 0 Depth를 기준으로 하도록 함.
  - Order 계산은 activeTodo를 기준으로 하며, 없을 경우 원점 오프셋을 하지 않도록 함.
  
## 관련 이슈

- #244 
