### PR TITLE
FIX: 제목 overflow ellipsis로 수정

### DIFF
--- a/client/src/container/TodoController.tsx
+++ b/client/src/container/TodoController.tsx
@@ -25,18 +25,31 @@ interface PropsType {
 }
 const Wrapper = styled.div<PropsType>`
   display: flex;
-  height: 8vh;
+  height: max-content;
   width: calc(100vw);
-  padding: 15px;
+  padding-inline: 15px;
+  padding-block: 0px;
   border-radius: 10px 10px 0 0;
   align-items: center;
   color: ${white};
   background-color: ${darkGray};
   justify-content: space-between;
   position: fixed;
-  bottom: ${(props) => (props.active ? '0vh' : '-8vh')};
-  transition-property: bottom;
+  bottom: 0;
+  transform: ${(props) => (props.active ? '0vh' : 'translateY(100%)')};
+  transition-property: transform;
   transition-duration: 1s;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+  min-width: 0;
+
+  & > p {
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+    min-width: 10px;
+  }
 `;
 
 const ButtonWrapper = styled.div`


### PR DESCRIPTION
## 개요
- 제목이 긴 경우 레이아웃이 짤리는 문제 발생하여 긴 경우 너비에 맞추어 `...` 처리

## 세부 내용
- todo Controller의 제목 overflow ellipsis로 수정

## 공유
- 고민과 질문
  
- flex에서 `overflow: ellipsis` 적용 잘 안되는 문제 발생
  - div 태그 대신 p tag에  넣어줌
  
- 관련 자료
  - https://stackoverflow.com/questions/51351137/css-text-overflow-ellipsis-not-working-in-grid-flex
   
## 관련 이슈

- #238 
