### PR TITLE
FIX: todoList.edit을 호출할 때 변경사항이 있는 property만 보내도록 수정

### DIFF
--- a/client/src/util/todos.util.ts
+++ b/client/src/util/todos.util.ts
@@ -37,8 +37,8 @@ export const getCheckTodoStateHandler = (
   return (event) => {
     let newTodo = {};
     event.stopPropagation();
-    if (todo.state === 'DONE') newTodo = { ...todo, state: 'READY' };
-    else if (todo.state === 'READY') newTodo = { ...todo, state: 'DONE' };
+    if (todo.state === 'DONE') newTodo = { id: todo.id, state: 'READY' };
+    else if (todo.state === 'READY') newTodo = { id: todo.id, state: 'DONE' };
     else if (todo.from.getTime() > new Date().getTime()) {
       toast.error('오늘 하루 동안 보지 않기로 설정한 할일입니다.');
       return;
@@ -46,7 +46,6 @@ export const getCheckTodoStateHandler = (
       toast.error('아직 먼저 할 일들이 끝나지 않은 할일입니다.');
       return;
     }
-    newTodo = { ...todo, state: todo.state === 'DONE' ? 'WAIT' : 'DONE' };
     todoListAtom
       .edit(todo.id, newTodo)
       .then((newTodoList) => {


### PR DESCRIPTION
## 개요
todoList.edit을 호출할 때 변경사항이 있는 property만 보내도록 수정

## 세부 내용
- 체크박스로 상호작용해서 todoList.edit을 수정할 때, state변경만을 하는 것이 아니라 다른 정보도 함께 송신함.
- 상호작용 할 때에 state 변경만 하도록 로직 수정.

## 공유
- 다른 edit 호출 함수들도 한번씩 체크할 필요가 있음.
  
## 관련 이슈
- #248 
