### PR TITLE
FEAT: table 뷰 elapsed time 보이게 수정 및 time interaction 개선

### DIFF
--- a/client/src/components/StartPauseButton.tsx
+++ b/client/src/components/StartPauseButton.tsx
@@ -1,0 +1,48 @@
+import { useAtom, useAtomValue, useSetAtom } from 'jotai';
+import { memo, ReactElement } from 'react';
+import { toast } from 'react-toastify';
+
+import Button from '@components/Button';
+import Pause from '@images/Pause';
+import Start from '@images/Start';
+import { elapsedTimeAtom, isOnProgress, setTimerAtom, todoList } from '@util/GlobalState';
+
+interface ImageButtonStyle {
+  fill?: string;
+  stroke?: string;
+  width?: string;
+  height?: string;
+}
+
+const StartPauseButton = (imageButtonStyle: ImageButtonStyle): ReactElement => {
+  const [progressState] = useAtom(isOnProgress);
+  const [todoListAtom, setTodoListAtom] = useAtom(todoList);
+  const elapsedTime = useAtomValue(elapsedTimeAtom);
+  const setTimer = useSetAtom(setTimerAtom);
+
+  const startPause = (): void => {
+    setTimer();
+
+    if (progressState !== 'working') {
+      return;
+    }
+
+    todoListAtom
+      .updateElapsedTime(elapsedTime)
+      .then((newTodoList) => {
+        setTodoListAtom(newTodoList);
+      })
+      .catch((err) => {
+        toast.error(err.message);
+      });
+  };
+
+  return (
+    <Button
+      context={progressState === 'working' ? <Pause {...imageButtonStyle} /> : <Start {...imageButtonStyle} />}
+      onClick={startPause}
+    />
+  );
+};
+
+export default memo(StartPauseButton);

--- a/client/src/components/main/TodoInteractionButton.tsx
+++ b/client/src/components/main/TodoInteractionButton.tsx
@@ -1,16 +1,15 @@
-import { useAtom, useSetAtom } from 'jotai';
-import { ReactElement, useMemo, memo } from 'react';
+import { useAtom, useAtomValue } from 'jotai';
+import { ReactElement, memo, useEffect } from 'react';
 
 import Button from '@components/Button';
 
-import Start from '@images/Start';
-import Pause from '@images/Pause';
 import Postpone from '@images/Postpone';
 import Done from '@images/Done';
 
-import { postponeClicked, isOnProgress, setTimerAtom } from '@util/GlobalState.js';
+import { asyncActiveTodo, elapsedTimeAtom, postponeClicked } from '@util/GlobalState.js';
 
 import useDone from '@hooks/useDone.js';
+import StartPauseButton from '@components/StartPauseButton';
 
 interface ImageButtonStyle {
   fill?: string;
@@ -21,18 +20,19 @@ interface ImageButtonStyle {
 
 const TodoInteractionButton = (imageButtonStyle: ImageButtonStyle): ReactElement => {
   const [isPostpone, setIsPostpone] = useAtom(postponeClicked);
-  const [progressState] = useAtom(isOnProgress);
   const [setDone] = useDone();
-  const setTimer = useSetAtom(setTimerAtom);
+  const [elapsedTime, setElapsedTime] = useAtom(elapsedTimeAtom);
+  const activeTodo = useAtomValue(asyncActiveTodo);
 
-  const startPauseButton = useMemo(() => {
-    const button = progressState === 'working' ? <Pause {...imageButtonStyle} /> : <Start {...imageButtonStyle} />;
-    return <Button context={button} onClick={setTimer} />;
-  }, [progressState]);
+  useEffect(() => {
+    if (activeTodo !== undefined && activeTodo.elapsedTime !== elapsedTime) {
+      setElapsedTime(activeTodo.elapsedTime);
+    }
+  }, [activeTodo]);
 
   return (
     <>
-      {startPauseButton}
+      <StartPauseButton {...imageButtonStyle} />
       <Button context={<Postpone {...imageButtonStyle} />} onClick={() => setIsPostpone(!isPostpone)} />
       <Button context={<Done {...imageButtonStyle} />} onClick={setDone} />
     </>

--- a/client/src/components/todos/TableRowDetail.tsx
+++ b/client/src/components/todos/TableRowDetail.tsx
@@ -2,13 +2,15 @@ import { ReactElement, memo } from 'react';
 import styled from 'styled-components';
 
 import { PRIMARY_COLORS, TABLE_ROW_DETAIL_TYPE } from '@util/Constants';
-import { isPlainTodo } from '@util/Common';
+import { getElapsedTimeText, isPlainTodo } from '@util/Common';
 import { PlainTodo } from '@todo/todo.type';
 
 import TodoTitleList from '@components/todos/TodoTitleList';
 import Text from '@components/Text';
+import { asyncActiveTodo, isOnProgress } from '@util/GlobalState';
+import { useAtomValue } from 'jotai';
 
-const { gray } = PRIMARY_COLORS;
+const { red } = PRIMARY_COLORS;
 
 const Wrapper = styled.div`
   display: flex;
@@ -29,16 +31,25 @@ const SubTitle = styled.h3`
   font-family: 'Noto Sans';
 `;
 
-const BlankDetailText = styled.p`
-  margin: 20px;
-  color: ${gray};
-`;
-
 const TalbleDetailElement = (type: string, info: PlainTodo | PlainTodo[]): ReactElement => {
   return (
     <>
       <SubTitle>{TABLE_ROW_DETAIL_TYPE[type as keyof typeof TABLE_ROW_DETAIL_TYPE]}</SubTitle>
       {isPlainTodo(info) ? <Text text={info.content} margin="16px 0" /> : <TodoTitleList list={info} />}
+    </>
+  );
+};
+
+const ElapsedTimeText = (todo: PlainTodo): ReactElement => {
+  const activeTodo = useAtomValue(asyncActiveTodo);
+  const isWorking = useAtomValue(isOnProgress);
+  return (
+    <>
+      {todo.id === activeTodo.id && isWorking === 'working' ? (
+        <Text text="진행중..." margin="16px 0" color={red} />
+      ) : (
+        <Text text={getElapsedTimeText(todo.elapsedTime)} margin="16px 0" />
+      )}
     </>
   );
 };
@@ -56,9 +67,8 @@ const TableRowDetail = ({
     <Wrapper>
       <BlankDiv />
       <DetailWrapper>
-        {todo.content === '' && todo.prev.length === 0 && todo.next.length === 0 && (
-          <BlankDetailText>할 일의 상세내용이 존재하지 않습니다</BlankDetailText>
-        )}
+        <SubTitle>소요시간</SubTitle>
+        {ElapsedTimeText(todo)}
         {todo.content !== '' && TalbleDetailElement('nowTodo', todo)}
         {prevTodoList.length > 0 && TalbleDetailElement('prevTodoList', prevTodoList)}
         {nextTodoList.length > 0 && TalbleDetailElement('nextTodoList', nextTodoList)}

--- a/client/src/container/TodoController.tsx
+++ b/client/src/container/TodoController.tsx
@@ -7,13 +7,7 @@ import Text from '@components/Text';
 import ElapsedTimeText from '@components/ElapsedTimeText';
 import TodoInteractionButton from '@components/main/TodoInteractionButton';
 
-import {
-  asyncActiveTodo,
-  elapsedTimeAtom,
-  isMainPageAtom,
-  needTodoControllerAtom,
-  postponeClicked,
-} from '@util/GlobalState';
+import { asyncActiveTodo, isMainPageAtom, needTodoControllerAtom, postponeClicked } from '@util/GlobalState';
 import { getTodoUntilText } from '@util/Common';
 import { PRIMARY_COLORS } from '@util/Constants';
 import PostponeBox from '@components/main/PostponeBox';
@@ -71,18 +65,10 @@ const imageButtonStyle = {
 
 const TodoController = (): ReactElement => {
   const location = useLocation();
-
   const activeTodo = useAtomValue(asyncActiveTodo);
   const [needTodoController, setNeedTodoController] = useAtom(needTodoControllerAtom);
   const setIsMainPage = useSetAtom(isMainPageAtom);
   const isPostpone = useAtomValue(postponeClicked);
-  const [elapsedTime, setElapsedTime] = useAtom(elapsedTimeAtom);
-
-  useEffect(() => {
-    if (activeTodo !== undefined && activeTodo.elapsedTime !== elapsedTime) {
-      setElapsedTime(activeTodo.elapsedTime);
-    }
-  }, [activeTodo]);
 
   useEffect(() => {
     setIsMainPage();

--- a/client/src/container/TodoController.tsx
+++ b/client/src/container/TodoController.tsx
@@ -52,8 +52,7 @@ const TextWrapper = styled.div`
   flex-direction: column;
   align-items: flex-end;
   white-space: nowrap;
-  overflow: hidden;
-  min-width: 0;
+  width: max-content;
 `;
 
 const imageButtonStyle = {
@@ -84,7 +83,13 @@ const TodoController = (): ReactElement => {
         <TodoInteractionButton {...imageButtonStyle} />
         {isPostpone && needTodoController && <PostponeBox isBottom={true} />}
       </ButtonWrapper>
-      <Text text={activeTodo?.title} fontFamily="Nanum Myeongjo" fontSize="24px" color={offWhite} />
+      <Text
+        text={activeTodo?.title}
+        fontFamily="Nanum Myeongjo"
+        fontSize="24px"
+        color={offWhite}
+        margin="0 40px 0 40px"
+      />
       <TextWrapper>
         <Text text={getTodoUntilText(activeTodo?.until)} fontFamily="Nanum Myeongjo" fontSize="1rem" color={offWhite} />
         <ElapsedTimeText color={offWhite} />

--- a/client/src/container/TodoController.tsx
+++ b/client/src/container/TodoController.tsx
@@ -33,10 +33,6 @@ const Wrapper = styled.div<PropsType>`
   transform: ${(props) => (props.active ? '0vh' : 'translateY(100%)')};
   transition-property: transform;
   transition-duration: 1s;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  overflow: hidden;
-  min-width: 0;
 
   & > p {
     text-overflow: ellipsis;
@@ -55,6 +51,9 @@ const TextWrapper = styled.div`
   display: flex;
   flex-direction: column;
   align-items: flex-end;
+  white-space: nowrap;
+  overflow: hidden;
+  min-width: 0;
 `;
 
 const imageButtonStyle = {

--- a/client/src/hooks/useModalComplete.ts
+++ b/client/src/hooks/useModalComplete.ts
@@ -1,20 +1,14 @@
-import { InputTodo } from '@todo/todo.type';
-import { TodoList } from '@todo/todoList';
-import { getTodayDate } from '@util/Common';
-import { MAX_DATE } from '@util/Constants';
-import { todoList } from '@util/GlobalState';
-import { useAtom } from 'jotai';
+import { useAtom, useAtomValue } from 'jotai';
 import { Dispatch, SetStateAction } from 'react';
-
 import { toast } from 'react-toastify';
 
-import 'react-toastify/dist/ReactToastify.css';
+import { InputTodo } from '@todo/todo.type';
+import { TodoList } from '@todo/todoList';
 
-interface ModalValues {
-  id: string;
-  value: string;
-  dataset: { label: string; id: string };
-}
+import { elapsedTimeAtom, todoList } from '@util/GlobalState';
+import { getCheckedInputData } from '@util/modal.util';
+
+import 'react-toastify/dist/ReactToastify.css';
 
 const MODAL_COMPLETE_ACTIONS = {
   create: async (todoList: TodoList, newData: InputTodo) => {
@@ -30,61 +24,35 @@ const COMPLETE_MESSAGE = {
   update: 'Todo가 수정되었습니다. ☘️',
 };
 
-const MODAL_CREATE = 'create';
-
 const useModalComplete = (type: string): any[] => {
   const [todoListAtom, setTodoListAtom] = useAtom(todoList);
+  const elapsedTime = useAtomValue(elapsedTimeAtom);
 
   const setComplete = async (
     inputData: any[],
     setHasModal: Dispatch<SetStateAction<boolean>>,
     editingTodoId: string,
   ): Promise<void> => {
-    try {
-      let newData = {};
-      const prevTodoIdList: string[] = [];
-      const nextTodoIdList: string[] = [];
-      inputData.forEach((item) => {
-        const { id, value, dataset }: ModalValues = item;
-
-        if (id === 'title' && value === '') {
-          throw new Error('제목은 필수 값입니다!');
-        }
-        if (id === 'title' && value.match(/[.*+?^${}()|[\]\\]/) !== null) {
-          throw new Error('제목은 ".*+?^${}()"의 특수문자가 허용되지 않습니다!');
-        }
-        if (id === 'until') {
-          const newDate = new Date(value);
-          if (isNaN(Number(newDate))) {
-            throw new Error('유효하지 않은 날짜입니다!');
-          }
-          if (newDate > new Date(MAX_DATE)) {
-            throw new Error('날짜는 2999-12-30 이후로 설정할 수 없습니다.');
-          }
-          if (type === MODAL_CREATE && newDate < new Date(getTodayDate())) {
-            throw new Error('새로 생성하는 할 일은 과거로 설정 불가능합니다.');
-          }
-          return (newData = { ...newData, [id]: newDate });
-        }
-
-        if (dataset.label === 'prev' || dataset.label === 'next') {
-          return dataset.label === 'prev' ? prevTodoIdList.push(dataset.id) : nextTodoIdList.push(dataset.id);
-        }
-        newData = { ...newData, [id]: value };
+    todoListAtom
+      .updateElapsedTime(elapsedTime)
+      .then((newTodoList) => {
+        return newTodoList;
+      })
+      .then(async (newTodoList) => {
+        return await MODAL_COMPLETE_ACTIONS[type as keyof typeof MODAL_COMPLETE_ACTIONS](
+          newTodoList,
+          getCheckedInputData(type, inputData),
+          editingTodoId,
+        );
+      })
+      .then((data) => {
+        setTodoListAtom(data);
+        setHasModal(false);
+        toast.success(COMPLETE_MESSAGE[type as keyof typeof COMPLETE_MESSAGE]);
+      })
+      .catch((err: any) => {
+        toast.error(err.message);
       });
-      newData = { ...newData, prev: prevTodoIdList, next: nextTodoIdList };
-
-      const data = await MODAL_COMPLETE_ACTIONS[type as keyof typeof MODAL_COMPLETE_ACTIONS](
-        todoListAtom,
-        newData,
-        editingTodoId,
-      );
-      setTodoListAtom(data);
-      setHasModal(false);
-      toast.success(COMPLETE_MESSAGE[type as keyof typeof COMPLETE_MESSAGE]);
-    } catch (err: any) {
-      toast.error(err.message);
-    }
   };
   return [setComplete];
 };

--- a/client/src/util/Common.ts
+++ b/client/src/util/Common.ts
@@ -72,3 +72,11 @@ export const copyToClipboard = (text: string): void => {
 export const isPlainTodo = (arg: any): arg is PlainTodo => {
   return arg.content !== undefined;
 };
+
+export const getElapsedTimeText = (time: number): string => {
+  const hour = Math.floor(time / 60 / 60);
+  const minute = Math.floor((time % 3600) / 60);
+  const second = time % 60;
+
+  return `${hour}h ${minute}m ${second}s`;
+};

--- a/client/src/util/GlobalState.ts
+++ b/client/src/util/GlobalState.ts
@@ -1,7 +1,8 @@
 import { atom } from 'jotai';
 import { createTodoList } from '@todo/todoList.js';
-import { TABLE_MODALS, POSTPONE_TEXTS, POSTPONE_OPTIONS } from '@util/Constants.js';
+import { POSTPONE_TEXTS, POSTPONE_OPTIONS } from '@util/Constants.js';
 import { isEqualDate } from '@todo/todo.util';
+import { getElapsedTimeText } from './Common';
 
 export const loginStateAtom = atom(true);
 export const isOnProgress = atom('relaxing');
@@ -95,6 +96,7 @@ export const setTimerAtom = atom(
       set(isOnProgress, 'working'); // start
       return;
     }
+
     clearInterval(timer);
     set(globalTimerAtom, -1);
     set(isOnProgress, 'relaxing'); // stop
@@ -115,11 +117,7 @@ export const displayTimeAtom = atom(
   (get) => get(displayTime),
   (get, set) => {
     const time = get(elapsedTimeAtom);
-    const hour = Math.floor(time / 60 / 60);
-    const minute = Math.floor((time % 3600) / 60);
-    const second = time % 60;
-
-    set(displayTime, `소요시간: ${hour}h ${minute}m ${second}s`);
+    set(displayTime, `소요시간: ${getElapsedTimeText(time)}`);
   },
 );
 

--- a/client/src/util/modal.util.ts
+++ b/client/src/util/modal.util.ts
@@ -1,3 +1,6 @@
+import { getTodayDate } from './Common';
+import { MAX_DATE } from './Constants';
+
 export const validatePrevAndNextId = (uuidArray: string[]): boolean => {
   const regex = /(\b[0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12}\b)/;
   if (uuidArray.length > 0) {
@@ -26,4 +29,54 @@ export const validateUuid = (uuid: string): boolean => {
   const regex = /(\b[0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12}\b)/;
   if (!regex.test(uuid)) throw new Error('먼저 할 일 또는 나중에 할 일의 id값이 올바르지 않습니다');
   return true;
+};
+
+interface ModalValues {
+  id: string;
+  value: string;
+  dataset: { label: string; id: string };
+}
+
+const MODAL_CREATE = 'create';
+
+interface CheckedInputData {
+  newData: any;
+  prev: string[];
+  next: string[];
+}
+export const getCheckedInputData = (type: string, inputData: ModalValues[]): CheckedInputData => {
+  let newData = {};
+  const prevTodoIdList: string[] = [];
+  const nextTodoIdList: string[] = [];
+
+  inputData.forEach((item) => {
+    const { id, value, dataset }: ModalValues = item;
+
+    if (id === 'title' && value === '') {
+      throw new Error('제목은 필수 값입니다!');
+    }
+    if (id === 'title' && value.match(/[.*+?^${}()|[\]\\]/) !== null) {
+      throw new Error('제목은 ".*+?^${}()"의 특수문자가 허용되지 않습니다!');
+    }
+    if (id === 'until') {
+      const newDate = new Date(value);
+      if (isNaN(Number(newDate))) {
+        throw new Error('유효하지 않은 날짜입니다!');
+      }
+      if (newDate > new Date(MAX_DATE)) {
+        throw new Error('날짜는 2999-12-30 이후로 설정할 수 없습니다.');
+      }
+      if (type === MODAL_CREATE && newDate < new Date(getTodayDate())) {
+        throw new Error('새로 생성하는 할 일은 과거로 설정 불가능합니다.');
+      }
+      return (newData = { ...newData, [id]: newDate });
+    }
+
+    if (dataset.label === 'prev' || dataset.label === 'next') {
+      return dataset.label === 'prev' ? prevTodoIdList.push(dataset.id) : nextTodoIdList.push(dataset.id);
+    }
+    newData = { ...newData, [id]: value };
+  });
+
+  return { newData, prev: prevTodoIdList, next: nextTodoIdList };
 };


### PR DESCRIPTION
## 개요
table 뷰 elapsed time 보이게 수정 및 time interaction 개선

## 세부 내용
- table view에서 elapsed time 보이게 수정
- 진행중인 active todo인 경우, 소요시간이 '진행중'으로 보이게 만듦
- 일시정지 시 elapsedTime update하도록 수정 (table view, todo controller의 데이터를 일치시키기 위해)
- modal 수정, create 이벤트 발생 시에도 updateElapsedTime 수행 (데이터 일치시키기)

![스크린샷 2022-12-15 오후 5 10 44](https://user-images.githubusercontent.com/39304306/207806677-20823c1f-2156-43bd-9538-d8f43c7ff22b.png)

## 공유

- 고민과 질문
  
- 뭔가 모달 action 후 데이터 변하는 시간이 더 오래걸려진 것 같습니다,, ㅜㅜ
  
## 관련 이슈

- #237 
